### PR TITLE
Fixed invisible overflow in homepage

### DIFF
--- a/_sass/_scorecard.scss
+++ b/_sass/_scorecard.scss
@@ -1,8 +1,3 @@
-html:has(.scorecard),
-body:has(.scorecard) {
-    scroll-snap-type: y proximity;
-}
-
 .scorecard__summary {
     display: grid;
     gap: map-get($spacers, 3);
@@ -195,6 +190,7 @@ body:has(.scorecard) {
 }
 
 .scorecard__data__table {
+    position: relative;
     @include media-breakpoint-up(sm) {
         width: 100%;
         overflow: auto;


### PR DESCRIPTION
https://github.com/user-attachments/assets/3e0258d7-7ba0-4ceb-9964-c19eb4976fb9


- Fixes the horizontal oveflow on mobile.
- Fixes the vertical overflow on desktop.
- Got rid of scroll-snap-type: y proximity; which was causing an odd behaviour while scrolling the page and ending up always being taken to the middle of the section table.